### PR TITLE
Docker buildx action for cross-CPU-architecture builds

### DIFF
--- a/.github/workflows/push-to-dockerhub.yml
+++ b/.github/workflows/push-to-dockerhub.yml
@@ -25,7 +25,7 @@ jobs:
         else
           echo ::set-output name=version::snapshot
         fi
-        echo ::set-output name=build_date::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+        echo ::set-output name=build_date::$(date +%s)
         echo ::set-output name=docker_platforms::linux/386,linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm64
         echo ::set-output name=docker_image::${{ secrets.DOCKER_USERNAME }}/mailhog
     - name: Set up Docker Buildx

--- a/.github/workflows/push-to-dockerhub.yml
+++ b/.github/workflows/push-to-dockerhub.yml
@@ -26,7 +26,7 @@ jobs:
           echo ::set-output name=version::snapshot
         fi
         echo ::set-output name=build_date::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-        echo ::set-output name=docker_platforms::linux/amd64,linux/arm/v7,linux/arm64
+        echo ::set-output name=docker_platforms::linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm64
         echo ::set-output name=docker_image::${{ secrets.DOCKER_USERNAME }}/mailhog
     - name: Set up Docker Buildx
       id: buildx

--- a/.github/workflows/push-to-dockerhub.yml
+++ b/.github/workflows/push-to-dockerhub.yml
@@ -59,7 +59,6 @@ jobs:
           --build-arg "VCS_REF=${GITHUB_SHA::8}" \
           --tag "${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}" \
           --tag "${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.build_date }}" \
-          --tag "${{ steps.prepare.outputs.docker_image }}:latest" \
           --file Dockerfile .
     - name: Clear
       if: always()

--- a/.github/workflows/push-to-dockerhub.yml
+++ b/.github/workflows/push-to-dockerhub.yml
@@ -26,7 +26,7 @@ jobs:
           echo ::set-output name=version::snapshot
         fi
         echo ::set-output name=build_date::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-        echo ::set-output name=docker_platforms::linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm64,linux/riscv64
+        echo ::set-output name=docker_platforms::linux/386,linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm64
         echo ::set-output name=docker_image::${{ secrets.DOCKER_USERNAME }}/mailhog
     - name: Set up Docker Buildx
       id: buildx

--- a/.github/workflows/push-to-dockerhub.yml
+++ b/.github/workflows/push-to-dockerhub.yml
@@ -26,7 +26,7 @@ jobs:
           echo ::set-output name=version::snapshot
         fi
         echo ::set-output name=build_date::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-        echo ::set-output name=docker_platforms::linux/amd64,linux/arm/v7,linux/arm64
+        echo ::set-output name=docker_platforms::linux/amd64,linux/arm64
         echo ::set-output name=docker_image::${{ secrets.DOCKER_USERNAME }}/mailhog
     - name: Set up Docker Buildx
       id: buildx

--- a/.github/workflows/push-to-dockerhub.yml
+++ b/.github/workflows/push-to-dockerhub.yml
@@ -26,7 +26,7 @@ jobs:
           echo ::set-output name=version::snapshot
         fi
         echo ::set-output name=build_date::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-        echo ::set-output name=docker_platforms::linux/amd64,linux/arm64
+        echo ::set-output name=docker_platforms::linux/amd64,linux/arm/v7,linux/arm64
         echo ::set-output name=docker_image::${{ secrets.DOCKER_USERNAME }}/mailhog
     - name: Set up Docker Buildx
       id: buildx

--- a/.github/workflows/push-to-dockerhub.yml
+++ b/.github/workflows/push-to-dockerhub.yml
@@ -58,6 +58,8 @@ jobs:
           --build-arg "BUILD_DATE=${{ steps.prepare.outputs.build_date }}" \
           --build-arg "VCS_REF=${GITHUB_SHA::8}" \
           --tag "${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}" \
+          --tag "${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.build_date }}" \
+          --tag "${{ steps.prepare.outputs.docker_image }}:latest" \
           --file Dockerfile .
     - name: Clear
       if: always()

--- a/.github/workflows/push-to-dockerhub.yml
+++ b/.github/workflows/push-to-dockerhub.yml
@@ -4,7 +4,7 @@ on:
   schedule:
   - cron: '0 0 1 * 0'
   push:
-    branches: [ master, docker-buildx-action ]
+    branches: [ master ]
 
 jobs:
 

--- a/.github/workflows/push-to-dockerhub.yml
+++ b/.github/workflows/push-to-dockerhub.yml
@@ -4,7 +4,7 @@ on:
   schedule:
   - cron: '0 0 1 * 0'
   push:
-    branches: [ master ]
+    branches: [ master, docker-buildx-action ]
 
 jobs:
 

--- a/.github/workflows/push-to-dockerhub.yml
+++ b/.github/workflows/push-to-dockerhub.yml
@@ -13,27 +13,53 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Prepare
+      id: prepare
+      run: |
+        if [[ $GITHUB_REF == refs/tags/* ]]; then
+          echo ::set-output name=version::${GITHUB_REF#refs/tags/v}
+        elif [[ $GITHUB_REF == refs/heads/master ]]; then
+          echo ::set-output name=version::latest
+        elif [[ $GITHUB_REF == refs/heads/* ]]; then
+          echo ::set-output name=version::${GITHUB_REF#refs/heads/}
+        else
+          echo ::set-output name=version::snapshot
+        fi
+        echo ::set-output name=build_date::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+        echo ::set-output name=docker_platforms::linux/amd64,linux/arm/v7,linux/arm64
+        echo ::set-output name=docker_image::${{ secrets.DOCKER_USERNAME }}/mailhog
     - name: Set up Docker Buildx
       id: buildx
       uses: crazy-max/ghaction-docker-buildx@v1
       with:
         version: latest
-    - name: Available platforms
-      run: echo ${{ steps.buildx.outputs.platforms }}
-
-  build:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
+    - name: Environment
+      run: |
+        echo home=$HOME
+        echo git_ref=$GITHUB_REF
+        echo git_sha=$GITHUB_SHA
+        echo version=${{ steps.prepare.outputs.version }}
+        echo date=${{ steps.prepare.outputs.build_date }}
+        echo image=${{ steps.prepare.outputs.docker_image }}
+        echo platforms=${{ steps.prepare.outputs.docker_platforms }}
+        echo avail_platforms=${{ steps.buildx.outputs.platforms }}
+          # https://github.com/actions/checkout
+    - name: Checkout
+      uses: actions/checkout@v2
     - name: Login to dockerhub
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
-    - name: Build the docker image
-      run: docker build . --file Dockerfile --tag cd2team/mailhog:build
-    - name: Tag and push
+    - name: Docker Buildx (push)
+      if: success()
       run: |
-        docker tag cd2team/mailhog:build cd2team/mailhog:latest
-        docker tag cd2team/mailhog:latest cd2team/mailhog:$(date +%s)
-        docker push cd2team/mailhog:$(date +%s)
-        docker push cd2team/mailhog:latest
+        docker buildx build \
+          --platform ${{ steps.prepare.outputs.docker_platforms }} \
+          --output "type=image,push=true" \
+          --build-arg "VERSION=${{ steps.prepare.outputs.version }}" \
+          --build-arg "BUILD_DATE=${{ steps.prepare.outputs.build_date }}" \
+          --build-arg "VCS_REF=${GITHUB_SHA::8}" \
+          --tag "${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}" \
+          --file Dockerfile .
+    - name: Clear
+      if: always()
+      run: |
+        rm -f ${HOME}/.docker/config.json

--- a/.github/workflows/push-to-dockerhub.yml
+++ b/.github/workflows/push-to-dockerhub.yml
@@ -8,6 +8,19 @@ on:
 
 jobs:
 
+  crossbuild:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: crazy-max/ghaction-docker-buildx@v1
+      with:
+      version: latest
+    - name: Available platforms
+      run: echo ${{ steps.buildx.outputs.platforms }}
+
   build:
 
     runs-on: ubuntu-latest

--- a/.github/workflows/push-to-dockerhub.yml
+++ b/.github/workflows/push-to-dockerhub.yml
@@ -26,7 +26,7 @@ jobs:
           echo ::set-output name=version::snapshot
         fi
         echo ::set-output name=build_date::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-        echo ::set-output name=docker_platforms::linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm64
+        echo ::set-output name=docker_platforms::linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm64,linux/riscv64
         echo ::set-output name=docker_image::${{ secrets.DOCKER_USERNAME }}/mailhog
     - name: Set up Docker Buildx
       id: buildx

--- a/.github/workflows/push-to-dockerhub.yml
+++ b/.github/workflows/push-to-dockerhub.yml
@@ -17,7 +17,7 @@ jobs:
       id: buildx
       uses: crazy-max/ghaction-docker-buildx@v1
       with:
-      version: latest
+        version: latest
     - name: Available platforms
       run: echo ${{ steps.buildx.outputs.platforms }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
-FROM alpine:latest
+FROM golang:1-alpine as builder
 MAINTAINER CD2Team <codesign2@icloud.com>
 
 RUN set -x \
-  && buildDeps='go git bzr musl-dev' \
+  && buildDeps='git bzr musl-dev gcc' \
   && apk add --update $buildDeps \
-  && GOPATH=/tmp/gocode go get github.com/mailhog/MailHog \
-  && mv /tmp/gocode/bin/MailHog /usr/local/bin/ \
-  && apk del $buildDeps \
-  && rm -rf /var/cache/apk/* /tmp/*
+  && GOPATH=/tmp/gocode go get github.com/mailhog/MailHog
 
+FROM alpine:latest
+WORKDIR /bin
+COPY --from=builder tmp/gocode/bin/MailHog /bin/MailHog
 EXPOSE 1025 8025
 ENTRYPOINT ["MailHog"]
-

--- a/README.md
+++ b/README.md
@@ -35,11 +35,9 @@ docker run --restart always --name mailhog -p 1025:1025 -p 8025:8025 -d mailhog:
 docker run --restart always --name mailhog -p 1025:1025 -p 8025:8025 -d cd2team/mailhog:latest
 ```
 
-There is also a pre-built x86 version under `cd2team/mailhog` with `latest` tag for rolling release built, tagged and pushed using Github Actions.
+There are also pre-built versions under `cd2team/mailhog` with `latest` tag for rolling release built, tagged and pushed using Github Actions. It's not robustly tested, but the tagging strategy used also means a timestamp release is published to ensure you can pin dependency versions.
 
-There are additionally `{timestamp}` version of tags, so that it's easy to maintain history when re-tagging a `latest` and `alpine`, and if you encounter issues with a `latest` tag.
-
-> **NOTE:** At present the automated builds are only run on x86 targets. If anyone has suggestions for this using GitHub actions, TravisCi, CircleCi, SemaphoreCI or another Cloud SaaS provider, please provide them via issue, or make a PR.
+The additional `{timestamp}` version of tags make it easy to maintain history when re-tagging a `latest` and `alpine`. If you encounter issues with a `latest` tag, please try the timestamp from your last successful build, which will share a hash with your last working `latest`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Use Docker buildx action for cross-CPU-architecture builds

Fixes #2 

Fairly minimal, although I have added a few hardware-platforms to the builds.

* Docker now uses multi-stage builds instead of an older clean-up step method
* Docker buildx builds tags with multiple architectures instead of a tag per arch
* Tagging strategy is
  * branch name (if enabled on non-master)
  * timestamp (so you can pin to a version)
  * release tag (on release publish, needs to be tested)
  * latest

HUGE thanks to 

* Dockerhub
* GitHub and the Actions team
* https://github.com/marketplace/actions/docker-buildx
* https://github.com/ginuerzh/gost/blob/master/Dockerfile