### PR TITLE
version -> buildx-version

### DIFF
--- a/.github/workflows/push-to-dockerhub.yml
+++ b/.github/workflows/push-to-dockerhub.yml
@@ -36,7 +36,7 @@ jobs:
       id: buildx
       uses: crazy-max/ghaction-docker-buildx@v1
       with:
-        version: latest
+        buildx-version: latest
     - name: Environment
       run: |
         echo home=$HOME


### PR DESCRIPTION
Obscure warnings have been bothering me. Why not get rid of them